### PR TITLE
refactor: refactor WithdrawalCursor and renaming some structs and functions

### DIFF
--- a/crates/block-producer/src/produce_block.rs
+++ b/crates/block-producer/src/produce_block.rs
@@ -22,8 +22,8 @@ use gw_types::{
     core::Status,
     offchain::BlockParam,
     packed::{
-        AccountMerkleState, BlockMerkleState, GlobalState, L2Block, LastFinalizedWithdrawal,
-        RawL2Block, SubmitTransactions, SubmitWithdrawals, WithdrawalRequestExtra,
+        AccountMerkleState, BlockMerkleState, GlobalState, L2Block, RawL2Block, SubmitTransactions,
+        SubmitWithdrawals, WithdrawalCursor, WithdrawalRequestExtra,
     },
     prelude::*,
 };
@@ -163,7 +163,7 @@ pub fn produce_block(
         .tip_block_hash(block.hash().pack())
         .tip_block_timestamp(block.raw().timestamp())
         .last_finalized_block_number(last_finalized_block_number.pack())
-        .last_finalized_withdrawal(last_finalized_withdrawal)
+        .finalized_withdrawal_cursor(last_finalized_withdrawal)
         .reverted_block_root(Into::<[u8; 32]>::into(reverted_block_root).pack())
         .rollup_config_hash(rollup_config_hash.pack())
         .status((Status::Running as u8).into())
@@ -176,16 +176,16 @@ pub fn produce_block(
     })
 }
 
-pub fn get_last_finalized_withdrawal(chain: &Chain) -> LastFinalizedWithdrawal {
+pub fn get_last_finalized_withdrawal(chain: &Chain) -> WithdrawalCursor {
     let last_global_state = chain.local_state().last_global_state();
 
     if last_global_state.version_u8() >= 2 {
-        last_global_state.last_finalized_withdrawal()
+        last_global_state.finalized_withdrawal_cursor()
     } else {
         // Upgrade to v2
-        LastFinalizedWithdrawal::new_builder()
+        WithdrawalCursor::new_builder()
             .block_number(chain.local_state().tip().raw().number())
-            .withdrawal_index(LastFinalizedWithdrawal::INDEX_ALL_WITHDRAWALS.pack())
+            .index(WithdrawalCursor::ALL_WITHDRAWALS.pack())
             .build()
     }
 }
@@ -196,7 +196,7 @@ pub fn generate_produce_block_param(
     store: &Store,
     mem_block: MemBlock,
     post_merkle_state: AccountMerkleState,
-    last_finalized_withdrawal: LastFinalizedWithdrawal,
+    last_finalized_withdrawal: WithdrawalCursor,
 ) -> Result<BlockParam> {
     let db = store.begin_transaction();
     let tip_block_number = mem_block.block_info().number().unpack().saturating_sub(1);

--- a/crates/block-producer/src/withdrawal.rs
+++ b/crates/block-producer/src/withdrawal.rs
@@ -8,12 +8,11 @@ use gw_common::{
 };
 use gw_types::{
     bytes::Bytes,
-    core::FinalizedWithdrawalIndex,
+    core::{WithdrawalCursor, WithdrawalCursorIndex},
     offchain::WithdrawalsAmount,
     packed::{
-        CKBMerkleProof, CellOutput, L2Block, LastFinalizedWithdrawal, RawL2BlockWithdrawals,
-        RawL2BlockWithdrawalsVec, RollupFinalizeWithdrawal, Script, WithdrawalRequest,
-        WithdrawalRequestExtra,
+        self, CKBMerkleProof, CellOutput, L2Block, RawL2BlockWithdrawals, RawL2BlockWithdrawalsVec,
+        RollupFinalizeWithdrawal, Script, WithdrawalRequest, WithdrawalRequestExtra,
     },
     prelude::*,
 };
@@ -53,28 +52,28 @@ impl BlockWithdrawals {
         BlockWithdrawals { block, range }
     }
 
-    pub fn from_rest(
+    pub fn build_from_remained(
         block: L2Block,
-        last_finalized: &LastFinalizedWithdrawal,
+        last_finalized: &packed::WithdrawalCursor,
     ) -> Result<Option<Self>> {
-        let (finalized_bn, finalized_idx) = last_finalized.unpack_block_index();
-        if finalized_bn != block.raw().number().unpack() {
+        let cursor = last_finalized.unpack_cursor();
+        if cursor.block_number != block.raw().number().unpack() {
             bail!("diff block and last finalized withdrawal block");
         }
 
-        let finalized_idx_val = match finalized_idx {
-            FinalizedWithdrawalIndex::AllWithdrawals => return Ok(None),
-            FinalizedWithdrawalIndex::Value(index) => index,
+        let finalized_index = match cursor.index {
+            WithdrawalCursorIndex::All => return Ok(None),
+            WithdrawalCursorIndex::Index(index) => index,
         };
         ensure!(!block.withdrawals().is_empty(), "block has withdrawals");
 
         let last_index = Self::last_index(&block).expect("valid finalized index");
-        let range = if finalized_idx_val == last_index {
+        let range = if finalized_index == last_index {
             // All withdrawals are finalized but the index isnt set to `INDEX_ALL_WITHDRAWALS`.
             // In this case, we must include this block into witness to do verification
             None
         } else {
-            Some((finalized_idx_val + 1, last_index))
+            Some((finalized_index + 1, last_index))
         };
 
         Ok(Some(BlockWithdrawals { block, range }))
@@ -172,19 +171,21 @@ impl BlockWithdrawals {
         Some(taken)
     }
 
-    pub fn to_last_finalized_withdrawal(&self) -> LastFinalizedWithdrawal {
-        let index = match self.range {
-            None => LastFinalizedWithdrawal::INDEX_ALL_WITHDRAWALS,
-            Some((_, end)) if Some(end) == Self::last_index(&self.block) => {
-                LastFinalizedWithdrawal::INDEX_ALL_WITHDRAWALS
-            }
-            Some((_, end)) => end,
+    pub fn to_last_finalized_withdrawal(&self) -> Result<packed::WithdrawalCursor> {
+        let raw_block = self.block.raw();
+        let cursor = match self.range {
+            None => WithdrawalCursor {
+                block_number: raw_block.number().unpack(),
+                index: WithdrawalCursorIndex::All,
+            },
+            Some((_, end)) => WithdrawalCursor::build_cursor(
+                raw_block.number().unpack(),
+                end,
+                raw_block.submit_withdrawals().withdrawal_count().unpack(),
+            )
+            .ok_or_else(|| anyhow!("failed to build cursor"))?,
         };
-
-        LastFinalizedWithdrawal::new_builder()
-            .block_number(self.block.raw().number())
-            .withdrawal_index(index.pack())
-            .build()
+        Ok(cursor.pack_cursor())
     }
 
     #[cfg(test)]
@@ -360,8 +361,8 @@ pub(crate) mod tests {
     use gw_mem_pool::custodian::sum_withdrawals;
     use gw_types::offchain::WithdrawalsAmount;
     use gw_types::packed::{
-        L2Block, LastFinalizedWithdrawal, RawL2Block, RawWithdrawalRequest, Script,
-        SubmitWithdrawals, WithdrawalRequest, WithdrawalRequestExtra,
+        self, L2Block, RawL2Block, RawWithdrawalRequest, Script, SubmitWithdrawals,
+        WithdrawalRequest, WithdrawalRequestExtra,
     };
     use gw_types::prelude::{Builder, Entity, Pack, PackVec};
 
@@ -548,12 +549,15 @@ pub(crate) mod tests {
         assert_eq!(blk_wthdrs.withdrawal_hashes().count(), 0);
         assert!(blk_wthdrs.clone().take(1).is_none());
         assert_eq!(
-            blk_wthdrs.to_last_finalized_withdrawal().as_slice(),
-            LastFinalizedWithdrawal::pack_block_index(
-                block.number(),
-                LastFinalizedWithdrawal::INDEX_ALL_WITHDRAWALS
-            )
-            .as_slice()
+            blk_wthdrs
+                .to_last_finalized_withdrawal()
+                .unwrap()
+                .as_slice(),
+            packed::WithdrawalCursor::new_builder()
+                .block_number(block.number().pack())
+                .index(packed::WithdrawalCursor::ALL_WITHDRAWALS.pack())
+                .build()
+                .as_slice()
         );
 
         assert!({ blk_wthdrs.verify_witness(&blk_wthdrs.generate_witness().unwrap()) }.is_ok());
@@ -576,12 +580,15 @@ pub(crate) mod tests {
         assert!({ blk_wthdrs.withdrawal_hashes() }.eq(expected_withdrawal_hashes.into_iter()));
 
         assert_eq!(
-            blk_wthdrs.to_last_finalized_withdrawal().as_slice(),
-            LastFinalizedWithdrawal::pack_block_index(
-                block.number(),
-                LastFinalizedWithdrawal::INDEX_ALL_WITHDRAWALS
-            )
-            .as_slice()
+            blk_wthdrs
+                .to_last_finalized_withdrawal()
+                .unwrap()
+                .as_slice(),
+            packed::WithdrawalCursor::new_builder()
+                .block_number(block.number().pack())
+                .index(packed::WithdrawalCursor::ALL_WITHDRAWALS.pack())
+                .build()
+                .as_slice()
         );
 
         assert!({ blk_wthdrs.verify_witness(&blk_wthdrs.generate_witness().unwrap()) }.is_ok());
@@ -592,8 +599,11 @@ pub(crate) mod tests {
         let mut store = BlockStore::default();
         let block = store.produce_block(5);
 
-        let last_finalized = LastFinalizedWithdrawal::pack_block_index(block.number(), 1);
-        let blk_wthdrs = BlockWithdrawals::from_rest(block.clone(), &last_finalized)
+        let last_finalized = packed::WithdrawalCursor::new_builder()
+            .block_number(block.number().pack())
+            .index(1u32.pack())
+            .build();
+        let blk_wthdrs = BlockWithdrawals::build_from_remained(block.clone(), &last_finalized)
             .unwrap()
             .unwrap();
         assert_eq!(blk_wthdrs.block.as_slice(), block.as_slice());
@@ -618,43 +628,53 @@ pub(crate) mod tests {
         assert!({ blk_wthdrs.withdrawal_hashes() }.eq(expected_withdrawal_hashes.into_iter()));
 
         assert_eq!(
-            blk_wthdrs.to_last_finalized_withdrawal().as_slice(),
-            LastFinalizedWithdrawal::pack_block_index(
-                block.number(),
-                LastFinalizedWithdrawal::INDEX_ALL_WITHDRAWALS
-            )
-            .as_slice()
+            blk_wthdrs
+                .to_last_finalized_withdrawal()
+                .unwrap()
+                .as_slice(),
+            packed::WithdrawalCursor::new_builder()
+                .block_number(block.number().pack())
+                .index(packed::WithdrawalCursor::ALL_WITHDRAWALS.pack())
+                .build()
+                .as_slice()
         );
 
         assert!({ blk_wthdrs.verify_witness(&blk_wthdrs.generate_witness().unwrap()) }.is_ok());
 
         // All withdrawal (no withdrwal)
         let block = store.produce_block(0);
-        let last_finalized = LastFinalizedWithdrawal::pack_block_index(
-            block.number(),
-            LastFinalizedWithdrawal::INDEX_ALL_WITHDRAWALS,
-        );
+        let last_finalized = packed::WithdrawalCursor::new_builder()
+            .block_number(block.number().pack())
+            .index(packed::WithdrawalCursor::ALL_WITHDRAWALS.pack())
+            .build();
 
-        assert!(BlockWithdrawals::from_rest(block, &last_finalized)
-            .unwrap()
-            .is_none());
+        assert!(
+            BlockWithdrawals::build_from_remained(block, &last_finalized)
+                .unwrap()
+                .is_none()
+        );
 
         // All withdrawals
         let block = store.produce_block(1);
-        let last_finalized = LastFinalizedWithdrawal::pack_block_index(
-            block.number(),
-            LastFinalizedWithdrawal::INDEX_ALL_WITHDRAWALS,
-        );
+        let last_finalized = packed::WithdrawalCursor::new_builder()
+            .block_number(block.number().pack())
+            .index(packed::WithdrawalCursor::ALL_WITHDRAWALS.pack())
+            .build();
 
-        assert!(BlockWithdrawals::from_rest(block, &last_finalized)
-            .unwrap()
-            .is_none());
+        assert!(
+            BlockWithdrawals::build_from_remained(block, &last_finalized)
+                .unwrap()
+                .is_none()
+        );
 
         // Last withdrawal index
         let block = store.produce_block(1);
-        let last_finalized = LastFinalizedWithdrawal::pack_block_index(block.number(), 0);
+        let last_finalized = packed::WithdrawalCursor::new_builder()
+            .block_number(block.number().pack())
+            .index(0u32.pack())
+            .build();
 
-        let blk_wthdrs = BlockWithdrawals::from_rest(block.clone(), &last_finalized)
+        let blk_wthdrs = BlockWithdrawals::build_from_remained(block.clone(), &last_finalized)
             .unwrap()
             .unwrap();
         assert_eq!(blk_wthdrs.block.as_slice(), block.as_slice());
@@ -667,12 +687,15 @@ pub(crate) mod tests {
         assert_eq!(blk_wthdrs.withdrawal_hashes().count(), 0);
 
         assert_eq!(
-            blk_wthdrs.to_last_finalized_withdrawal().as_slice(),
-            LastFinalizedWithdrawal::pack_block_index(
-                block.number(),
-                LastFinalizedWithdrawal::INDEX_ALL_WITHDRAWALS
-            )
-            .as_slice()
+            blk_wthdrs
+                .to_last_finalized_withdrawal()
+                .unwrap()
+                .as_slice(),
+            packed::WithdrawalCursor::new_builder()
+                .block_number(block.number().pack())
+                .index(packed::WithdrawalCursor::ALL_WITHDRAWALS.pack())
+                .build()
+                .as_slice()
         );
 
         assert!({ blk_wthdrs.verify_witness(&blk_wthdrs.generate_witness().unwrap()) }.is_ok());
@@ -692,16 +715,21 @@ pub(crate) mod tests {
 
         // Diff block
         let other = store.produce_block(10);
-        let last_finalized = BlockWithdrawals::new(other).to_last_finalized_withdrawal();
+        let last_finalized = BlockWithdrawals::new(other)
+            .to_last_finalized_withdrawal()
+            .unwrap();
 
-        let err = BlockWithdrawals::from_rest(block, &last_finalized).unwrap_err();
+        let err = BlockWithdrawals::build_from_remained(block, &last_finalized).unwrap_err();
         assert!({ err.to_string() }.contains("diff block and last finalized withdrawal block"));
 
         // Block no withdrawal
         let block = store.produce_block(0);
-        let last_finalized = LastFinalizedWithdrawal::pack_block_index(block.number(), 0);
+        let last_finalized = packed::WithdrawalCursor::new_builder()
+            .block_number(block.number().pack())
+            .index(0u32.pack())
+            .build();
 
-        let err = BlockWithdrawals::from_rest(block, &last_finalized).unwrap_err();
+        let err = BlockWithdrawals::build_from_remained(block, &last_finalized).unwrap_err();
         assert!({ err.to_string() }.contains("block has withdrawals"));
     }
 

--- a/crates/block-producer/src/withdrawal_finalizer.rs
+++ b/crates/block-producer/src/withdrawal_finalizer.rs
@@ -29,8 +29,8 @@ use gw_types::{
         global_state_from_slice, CollectedCustodianCells, InputCellInfo, RollupContext, TxStatus,
     },
     packed::{
-        CellDep, CellInput, L2Block, LastFinalizedWithdrawal, RollupAction, RollupActionUnion,
-        Script, Transaction, WithdrawalRequestExtra, WitnessArgs,
+        CellDep, CellInput, L2Block, RollupAction, RollupActionUnion, Script, Transaction,
+        WithdrawalCursor, WithdrawalRequestExtra, WitnessArgs,
     },
     prelude::{Builder, Entity, FromSliceShouldBeOk, Pack, Unpack},
 };
@@ -135,7 +135,7 @@ impl UserWithdrawalFinalizer {
 
             match rpc_client.send_transaction(&tx).await {
                 Ok(tx_hash) => {
-                    tracing::info!(tx_hash = %tx_hash.pack(), blk_idx = ?(pending_finalized.unpack_block_index()), "finalize withdrawal");
+                    tracing::info!(tx_hash = %tx_hash.pack(), blk_idx = ?(pending_finalized.unpack_cursor()), "finalize withdrawal");
                     self.set_last_finalize_tx(Some(tx_hash))?;
                 }
                 Err(err) => bail!("send finalize withdrawal tx failed {}", err),
@@ -187,7 +187,7 @@ pub trait FinalizeWithdrawalToOwner {
 
     fn get_pending_finalized_withdrawals(
         &self,
-        last_finalized_withdrawal: &LastFinalizedWithdrawal,
+        last_finalized_withdrawal: &WithdrawalCursor,
         last_finalized_block_number: u64,
     ) -> Result<Option<Vec<BlockWithdrawals>>>;
 
@@ -201,9 +201,7 @@ pub trait FinalizeWithdrawalToOwner {
 
     async fn complete_tx(&self, tx_skeleton: TransactionSkeleton) -> Result<Transaction>;
 
-    async fn query_and_finalize_to_owner(
-        &self,
-    ) -> Result<Option<(Transaction, LastFinalizedWithdrawal)>> {
+    async fn query_and_finalize_to_owner(&self) -> Result<Option<(Transaction, WithdrawalCursor)>> {
         let rollup_input = match self.query_rollup_cell().await? {
             Some(cell) => cell,
             None => {
@@ -235,7 +233,7 @@ pub trait FinalizeWithdrawalToOwner {
         };
 
         let last_finalized_block_number: u64 = global_state.last_finalized_block_number().unpack();
-        let last_finalized_withdrawal = global_state.last_finalized_withdrawal();
+        let last_finalized_withdrawal = global_state.finalized_withdrawal_cursor();
 
         let block_withdrawals = match self.get_pending_finalized_withdrawals(
             &last_finalized_withdrawal,
@@ -265,11 +263,11 @@ pub trait FinalizeWithdrawalToOwner {
 
         let last_finalized_withdrawal =
             { block_withdrawals.last().expect("last block withdrawals") }
-                .to_last_finalized_withdrawal();
+                .to_last_finalized_withdrawal()?;
 
         let rollup_output = {
             let post_global_state = { global_state.clone().as_builder() }
-                .last_finalized_withdrawal(last_finalized_withdrawal.clone())
+                .finalized_withdrawal_cursor(last_finalized_withdrawal.clone())
                 .build();
 
             (
@@ -472,7 +470,7 @@ impl FinalizeWithdrawalToOwner for DefaultFinalizer {
 
     fn get_pending_finalized_withdrawals(
         &self,
-        last_finalized_withdrawal: &LastFinalizedWithdrawal,
+        last_finalized_withdrawal: &WithdrawalCursor,
         last_finalized_block_number: u64,
     ) -> Result<Option<Vec<BlockWithdrawals>>> {
         get_pending_finalized_withdrawals(
@@ -526,11 +524,11 @@ impl FinalizeWithdrawalToOwner for DefaultFinalizer {
 fn get_pending_finalized_withdrawals(
     store: &impl ChainStore,
     pending: &PendingFinalizedWithdrawal,
-    last_finalized_withdrawal: &LastFinalizedWithdrawal,
+    last_finalized_withdrawal_cursor: &WithdrawalCursor,
     last_finalized_block_number: u64,
 ) -> Result<Option<Vec<BlockWithdrawals>>> {
-    let (last_wthdr_bn, last_wthdr_idx) = last_finalized_withdrawal.unpack_block_index();
-    tracing::debug!(finalized_withdrawal = ?(last_wthdr_bn, last_wthdr_idx), "get pending finalized");
+    let withdrawal_cursor = last_finalized_withdrawal_cursor.unpack_cursor();
+    tracing::debug!(finalized_withdrawal = ?(withdrawal_cursor), "get pending finalized");
 
     let ensure_get_block = |num: u64| -> Result<L2Block> {
         match store.get_block_by_number(num)? {
@@ -539,15 +537,18 @@ fn get_pending_finalized_withdrawals(
         }
     };
 
-    let next_pending_blk_wthdrs_on_chain = match BlockWithdrawals::from_rest(
-        ensure_get_block(last_wthdr_bn)?,
-        last_finalized_withdrawal,
+    let next_pending_blk_wthdrs_on_chain = match BlockWithdrawals::build_from_remained(
+        ensure_get_block(withdrawal_cursor.block_number)?,
+        last_finalized_withdrawal_cursor,
     )? {
         Some(blk_wthdrs) => blk_wthdrs,
-        None => match store.get_block_by_number(last_wthdr_bn + 1)? {
+        None => match store.get_block_by_number(withdrawal_cursor.block_number + 1)? {
             Some(blk) => BlockWithdrawals::new(blk),
             None => {
-                tracing::debug!(blk = last_wthdr_bn + 1, "pending finalized block not found");
+                tracing::debug!(
+                    blk = withdrawal_cursor.block_number + 1,
+                    "pending finalized block not found"
+                );
                 return Ok(None);
             }
         },
@@ -687,7 +688,10 @@ impl PendingFinalizedWithdrawal {
 mod tests {
     use gw_db::schema::Col;
     use gw_store::traits::kv_store::KVStoreRead;
-    use gw_types::{offchain::CellInfo, packed::GlobalState};
+    use gw_types::{
+        offchain::CellInfo,
+        packed::{self, GlobalState},
+    };
 
     use super::*;
     use crate::withdrawal::tests::BlockStore;
@@ -732,7 +736,7 @@ mod tests {
 
             fn get_pending_finalized_withdrawals(
                 &self,
-                last_finalized_withdrawal: &LastFinalizedWithdrawal,
+                last_finalized_withdrawal: &WithdrawalCursor,
                 last_finalized_block_number: u64,
             ) -> Result<Option<Vec<BlockWithdrawals>>>;
 
@@ -759,10 +763,10 @@ mod tests {
         let three = store.produce_block(2);
         let four = store.produce_block(3);
 
-        let last_finalized = LastFinalizedWithdrawal::pack_block_index(
-            zero.number(),
-            LastFinalizedWithdrawal::INDEX_ALL_WITHDRAWALS,
-        );
+        let last_finalized = packed::WithdrawalCursor::new_builder()
+            .block_number(zero.number().pack())
+            .index(packed::WithdrawalCursor::ALL_WITHDRAWALS.pack())
+            .build();
 
         // Next pending block > last_finalized_block_number
         let ret = get_pending_finalized_withdrawals(&store, &pending, &last_finalized, 0).unwrap();
@@ -806,10 +810,10 @@ mod tests {
         assert_eq!(pending.block_range(), None);
 
         // Max withdrawals
-        let last_finalized = LastFinalizedWithdrawal::pack_block_index(
-            one.number(),
-            LastFinalizedWithdrawal::INDEX_ALL_WITHDRAWALS,
-        );
+        let last_finalized = packed::WithdrawalCursor::new_builder()
+            .block_number(one.number().pack())
+            .index(packed::WithdrawalCursor::ALL_WITHDRAWALS.pack())
+            .build();
         let fulfilled = get_pending_finalized_withdrawals(&store, &pending, &last_finalized, 4)
             .unwrap()
             .unwrap();
@@ -830,10 +834,10 @@ mod tests {
         let zero = store.produce_block(0);
 
         // Next pending block on chain not found
-        let last_finalized = LastFinalizedWithdrawal::pack_block_index(
-            zero.number(),
-            LastFinalizedWithdrawal::INDEX_ALL_WITHDRAWALS,
-        );
+        let last_finalized = packed::WithdrawalCursor::new_builder()
+            .block_number(zero.number().pack())
+            .index(packed::WithdrawalCursor::ALL_WITHDRAWALS.pack())
+            .build();
 
         let ret = get_pending_finalized_withdrawals(&store, &pending, &last_finalized, 1).unwrap();
         assert!(ret.is_none());
@@ -857,20 +861,20 @@ mod tests {
         let two = store.produce_block(1);
         let three = store.produce_block(2);
 
-        let last_finalized = LastFinalizedWithdrawal::pack_block_index(
-            one.number(),
-            LastFinalizedWithdrawal::INDEX_ALL_WITHDRAWALS,
-        );
+        let last_finalized = packed::WithdrawalCursor::new_builder()
+            .block_number(one.number().pack())
+            .index(packed::WithdrawalCursor::ALL_WITHDRAWALS.pack())
+            .build();
 
         let ret = get_pending_finalized_withdrawals(&store, &pending, &last_finalized, 2).unwrap();
         assert!(ret.is_none());
         assert_eq!(pending.block_range(), Some(two.number()..=two.number()));
 
         // range.start() != next_pending_blk_num_on_chain
-        let reorg_last_finalized = LastFinalizedWithdrawal::pack_block_index(
-            zero.number(),
-            LastFinalizedWithdrawal::INDEX_ALL_WITHDRAWALS,
-        );
+        let reorg_last_finalized = packed::WithdrawalCursor::new_builder()
+            .block_number(zero.number().pack())
+            .index(packed::WithdrawalCursor::ALL_WITHDRAWALS.pack())
+            .build();
 
         let ret =
             get_pending_finalized_withdrawals(&store, &pending, &reorg_last_finalized, 2).unwrap();
@@ -878,10 +882,10 @@ mod tests {
         assert_eq!(pending.block_range(), None);
 
         // range.end() > last_finalized_block_number
-        let last_finalized = LastFinalizedWithdrawal::pack_block_index(
-            one.number(),
-            LastFinalizedWithdrawal::INDEX_ALL_WITHDRAWALS,
-        );
+        let last_finalized = packed::WithdrawalCursor::new_builder()
+            .block_number(one.number().pack())
+            .index(packed::WithdrawalCursor::ALL_WITHDRAWALS.pack())
+            .build();
 
         let ret = get_pending_finalized_withdrawals(&store, &pending, &last_finalized, 3).unwrap();
         assert!(ret.is_none());
@@ -893,10 +897,10 @@ mod tests {
         assert_eq!(pending.block_range(), None);
 
         // push error
-        let last_finalized = LastFinalizedWithdrawal::pack_block_index(
-            one.number(),
-            LastFinalizedWithdrawal::INDEX_ALL_WITHDRAWALS,
-        );
+        let last_finalized = packed::WithdrawalCursor::new_builder()
+            .block_number(one.number().pack())
+            .index(packed::WithdrawalCursor::ALL_WITHDRAWALS.pack())
+            .build();
 
         let ret = get_pending_finalized_withdrawals(&store, &pending, &last_finalized, 3).unwrap();
         assert!(ret.is_none());

--- a/crates/chain/src/chain.rs
+++ b/crates/chain/src/chain.rs
@@ -601,11 +601,9 @@ impl Chain {
                     let status: u8 = global_state.status().into();
                     assert_eq!(Status::try_from(status), Ok(Status::Running));
 
-                    let (block_number, index) = global_state
-                        .last_finalized_withdrawal()
-                        .unpack_block_index();
+                    let cursor = global_state.finalized_withdrawal_cursor().unpack_cursor();
 
-                    log::info!("last finalized withdrawal to {} {:?}", block_number, index);
+                    log::info!("last finalized withdrawal to {:?}", cursor);
 
                     Ok(SyncEvent::Success)
                 }

--- a/crates/tests/src/tests/deprecated/unlock_withdrawal_to_owner.rs
+++ b/crates/tests/src/tests/deprecated/unlock_withdrawal_to_owner.rs
@@ -30,8 +30,8 @@ use gw_types::core::{AllowedEoaType, DepType, ScriptHashType};
 use gw_types::offchain::{CellInfo, CollectedCustodianCells, InputCellInfo, RollupContext};
 use gw_types::packed::{
     AllowedTypeHash, CellDep, CellInput, CellOutput, CustodianLockArgs, DepositRequest,
-    GlobalState, LastFinalizedWithdrawal, OutPoint, RawWithdrawalRequest, RollupAction,
-    RollupActionUnion, RollupConfig, RollupSubmitBlock, Script, StakeLockArgs, WithdrawalRequest,
+    GlobalState, OutPoint, RawWithdrawalRequest, RollupAction, RollupActionUnion, RollupConfig,
+    RollupSubmitBlock, Script, StakeLockArgs, WithdrawalCursor, WithdrawalRequest,
     WithdrawalRequestExtra, WitnessArgs,
 };
 use gw_types::prelude::{Pack, PackVec, Unpack};
@@ -770,7 +770,7 @@ fn random_always_success_script(opt_rollup_script_hash: Option<&H256>) -> Script
 
 fn ensure_global_state_v1(global_state: GlobalState) -> GlobalState {
     { global_state.as_builder() }
-        .last_finalized_withdrawal(LastFinalizedWithdrawal::default())
+        .finalized_withdrawal_cursor(WithdrawalCursor::default())
         .version(1u8.into())
         .build()
 }

--- a/crates/tests/src/tests/finalize_withdrawal_to_owner.rs
+++ b/crates/tests/src/tests/finalize_withdrawal_to_owner.rs
@@ -29,9 +29,9 @@ use gw_types::core::{AllowedEoaType, DepType, ScriptHashType};
 use gw_types::offchain::{CellInfo, CollectedCustodianCells, InputCellInfo, RollupContext};
 use gw_types::packed::{
     AllowedTypeHash, CellDep, CellInput, CellOutput, CustodianLockArgs, DepositRequest,
-    GlobalState, LastFinalizedWithdrawal, OutPoint, RawWithdrawalRequest, RollupAction,
-    RollupActionUnion, RollupConfig, RollupSubmitBlock, Script, ScriptVec, StakeLockArgs,
-    WithdrawalRequest, WithdrawalRequestExtra, WitnessArgs,
+    GlobalState, OutPoint, RawWithdrawalRequest, RollupAction, RollupActionUnion, RollupConfig,
+    RollupSubmitBlock, Script, ScriptVec, StakeLockArgs, WithdrawalCursor, WithdrawalRequest,
+    WithdrawalRequestExtra, WitnessArgs,
 };
 use gw_types::prelude::{Pack, PackVec, Unpack};
 use gw_utils::transaction_skeleton::TransactionSkeleton;
@@ -480,13 +480,13 @@ async fn test_finalize_withdrawal_to_owner() {
         into_input_cell(input_custodian_cell),
     ];
 
-    let (last_finalized_withdrawal_block, _) = chain
+    let withdrawal_cursor = chain
         .last_global_state()
-        .last_finalized_withdrawal()
-        .unpack_block_index();
+        .finalized_withdrawal_cursor()
+        .unpack_cursor();
 
     // Finalize block without withdrawal
-    finalizer.pending = (last_finalized_withdrawal_block + 1..=(withdrawal_block_number + 1))
+    finalizer.pending = (withdrawal_cursor.block_number + 1..=(withdrawal_block_number + 1))
         .map(|bn| BlockWithdrawals::new(chain.store().get_block_by_number(bn).unwrap().unwrap()))
         .collect::<Vec<_>>();
 
@@ -494,9 +494,9 @@ async fn test_finalize_withdrawal_to_owner() {
         .unwrap()
         .unwrap();
 
-    let expected_updated_last_finalized = LastFinalizedWithdrawal::new_builder()
+    let expected_updated_last_finalized = WithdrawalCursor::new_builder()
         .block_number((withdrawal_block_number + 1).pack())
-        .withdrawal_index(LastFinalizedWithdrawal::INDEX_ALL_WITHDRAWALS.pack())
+        .index(WithdrawalCursor::ALL_WITHDRAWALS.pack())
         .build();
 
     assert_eq!(
@@ -513,7 +513,7 @@ async fn test_finalize_withdrawal_to_owner() {
     verify_tx(tx_with_context, 7000_0000u64).expect("pass");
 
     // Finalize all withdrawals
-    finalizer.pending = (last_finalized_withdrawal_block + 1..=withdrawal_block_number)
+    finalizer.pending = (withdrawal_cursor.block_number + 1..=withdrawal_block_number)
         .map(|bn| BlockWithdrawals::new(chain.store().get_block_by_number(bn).unwrap().unwrap()))
         .collect::<Vec<_>>();
 
@@ -521,9 +521,9 @@ async fn test_finalize_withdrawal_to_owner() {
         .unwrap()
         .unwrap();
 
-    let expected_updated_last_finalized = LastFinalizedWithdrawal::new_builder()
+    let expected_updated_last_finalized = WithdrawalCursor::new_builder()
         .block_number(withdrawal_block_number.pack())
-        .withdrawal_index(LastFinalizedWithdrawal::INDEX_ALL_WITHDRAWALS.pack())
+        .index(WithdrawalCursor::ALL_WITHDRAWALS.pack())
         .build();
 
     assert_eq!(
@@ -540,7 +540,7 @@ async fn test_finalize_withdrawal_to_owner() {
     verify_tx(tx_with_context, 7000_0000u64).expect("pass");
 
     // Finalize partial withdrawals
-    finalizer.pending = (last_finalized_withdrawal_block + 1..=withdrawal_block_number)
+    finalizer.pending = (withdrawal_cursor.block_number + 1..=withdrawal_block_number)
         .map(|bn| BlockWithdrawals::new(chain.store().get_block_by_number(bn).unwrap().unwrap()))
         .collect::<Vec<_>>();
     let last_block_withdrawals = finalizer.pending.pop().unwrap();
@@ -550,9 +550,9 @@ async fn test_finalize_withdrawal_to_owner() {
         .unwrap()
         .unwrap();
 
-    let expected_updated_last_finalized = LastFinalizedWithdrawal::new_builder()
+    let expected_updated_last_finalized = WithdrawalCursor::new_builder()
         .block_number(withdrawal_block_number.pack())
-        .withdrawal_index(0u32.pack())
+        .index(0u32.pack())
         .build();
 
     assert_eq!(
@@ -572,14 +572,14 @@ async fn test_finalize_withdrawal_to_owner() {
     let last_finalized = updated_last_finalized;
     let global_state = { chain.last_global_state().clone() }
         .as_builder()
-        .last_finalized_withdrawal(last_finalized.clone())
+        .finalized_withdrawal_cursor(last_finalized.clone())
         .build();
     finalizer.rollup_cell.data = global_state.as_bytes();
 
     let mut inputs = inputs;
     inputs[0] = into_input_cell(finalizer.rollup_cell.clone());
 
-    finalizer.pending = vec![BlockWithdrawals::from_rest(
+    finalizer.pending = vec![BlockWithdrawals::build_from_remained(
         { chain.store() }
             .get_block_by_number(last_finalized.block_number().unpack())
             .unwrap()
@@ -593,9 +593,9 @@ async fn test_finalize_withdrawal_to_owner() {
         .unwrap()
         .unwrap();
 
-    let expected_updated_last_finalized = LastFinalizedWithdrawal::new_builder()
+    let expected_updated_last_finalized = WithdrawalCursor::new_builder()
         .block_number(withdrawal_block_number.pack())
-        .withdrawal_index(LastFinalizedWithdrawal::INDEX_ALL_WITHDRAWALS.pack())
+        .index(WithdrawalCursor::ALL_WITHDRAWALS.pack())
         .build();
 
     assert_eq!(
@@ -672,7 +672,7 @@ impl FinalizeWithdrawalToOwner for DummyFinalizer {
 
     fn get_pending_finalized_withdrawals(
         &self,
-        _last_finalized_withdrawal: &LastFinalizedWithdrawal,
+        _last_finalized_withdrawal: &WithdrawalCursor,
         _last_finalized_block_number: u64,
     ) -> Result<Option<Vec<BlockWithdrawals>>> {
         Ok(Some(self.pending.clone()))

--- a/crates/types/schemas/godwoken.mol
+++ b/crates/types/schemas/godwoken.mol
@@ -14,16 +14,17 @@ struct AccountMerkleState {
 
 // NOTE:
 //
+// This structure is used to track the finalized withdrawals
+//
 // special flags:
 // 
-// u32::MAX (aka 4294967295) means all withdrawals in a block are finalized
+// u32::MAX (aka 4294967295) means all withdrawals in the block are processed
 //
-// If a block's `withdrawal_index` is set to above value in the `GlobalState`,
-// we don't need to submit that raw block to verify prev `last_finalized_withdrawal`
-// transition.
-struct LastFinalizedWithdrawal {
+// If a block's `index` is set to above value in the `GlobalState.last_finalized_withdrawal_cursor`,
+// then we can start from the next block to verify the finalized withdrawals.
+struct WithdrawalCursor {
     block_number: Uint64,
-    withdrawal_index: Uint32,
+    index: Uint32,
 }
 
 struct GlobalStateV1 {
@@ -48,7 +49,7 @@ struct GlobalState {
     tip_block_hash: Byte32,
     tip_block_timestamp: Uint64,
     last_finalized_block_number: Uint64,
-    last_finalized_withdrawal: LastFinalizedWithdrawal,
+    finalized_withdrawal_cursor: WithdrawalCursor,
     // 0: running, 1: halting
     status: byte,
     version: byte,

--- a/crates/types/src/generated/godwoken.rs
+++ b/crates/types/src/generated/godwoken.rs
@@ -601,8 +601,8 @@ impl molecule::prelude::Builder for AccountMerkleStateBuilder {
     }
 }
 #[derive(Clone)]
-pub struct LastFinalizedWithdrawal(molecule::bytes::Bytes);
-impl ::core::fmt::LowerHex for LastFinalizedWithdrawal {
+pub struct WithdrawalCursor(molecule::bytes::Bytes);
+impl ::core::fmt::LowerHex for WithdrawalCursor {
     fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
         use molecule::hex_string;
         if f.alternate() {
@@ -611,44 +611,44 @@ impl ::core::fmt::LowerHex for LastFinalizedWithdrawal {
         write!(f, "{}", hex_string(self.as_slice()))
     }
 }
-impl ::core::fmt::Debug for LastFinalizedWithdrawal {
+impl ::core::fmt::Debug for WithdrawalCursor {
     fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
         write!(f, "{}({:#x})", Self::NAME, self)
     }
 }
-impl ::core::fmt::Display for LastFinalizedWithdrawal {
+impl ::core::fmt::Display for WithdrawalCursor {
     fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
         write!(f, "{} {{ ", Self::NAME)?;
         write!(f, "{}: {}", "block_number", self.block_number())?;
-        write!(f, ", {}: {}", "withdrawal_index", self.withdrawal_index())?;
+        write!(f, ", {}: {}", "index", self.index())?;
         write!(f, " }}")
     }
 }
-impl ::core::default::Default for LastFinalizedWithdrawal {
+impl ::core::default::Default for WithdrawalCursor {
     fn default() -> Self {
         let v: Vec<u8> = vec![0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
-        LastFinalizedWithdrawal::new_unchecked(v.into())
+        WithdrawalCursor::new_unchecked(v.into())
     }
 }
-impl LastFinalizedWithdrawal {
+impl WithdrawalCursor {
     pub const TOTAL_SIZE: usize = 12;
     pub const FIELD_SIZES: [usize; 2] = [8, 4];
     pub const FIELD_COUNT: usize = 2;
     pub fn block_number(&self) -> Uint64 {
         Uint64::new_unchecked(self.0.slice(0..8))
     }
-    pub fn withdrawal_index(&self) -> Uint32 {
+    pub fn index(&self) -> Uint32 {
         Uint32::new_unchecked(self.0.slice(8..12))
     }
-    pub fn as_reader<'r>(&'r self) -> LastFinalizedWithdrawalReader<'r> {
-        LastFinalizedWithdrawalReader::new_unchecked(self.as_slice())
+    pub fn as_reader<'r>(&'r self) -> WithdrawalCursorReader<'r> {
+        WithdrawalCursorReader::new_unchecked(self.as_slice())
     }
 }
-impl molecule::prelude::Entity for LastFinalizedWithdrawal {
-    type Builder = LastFinalizedWithdrawalBuilder;
-    const NAME: &'static str = "LastFinalizedWithdrawal";
+impl molecule::prelude::Entity for WithdrawalCursor {
+    type Builder = WithdrawalCursorBuilder;
+    const NAME: &'static str = "WithdrawalCursor";
     fn new_unchecked(data: molecule::bytes::Bytes) -> Self {
-        LastFinalizedWithdrawal(data)
+        WithdrawalCursor(data)
     }
     fn as_bytes(&self) -> molecule::bytes::Bytes {
         self.0.clone()
@@ -657,10 +657,10 @@ impl molecule::prelude::Entity for LastFinalizedWithdrawal {
         &self.0[..]
     }
     fn from_slice(slice: &[u8]) -> molecule::error::VerificationResult<Self> {
-        LastFinalizedWithdrawalReader::from_slice(slice).map(|reader| reader.to_entity())
+        WithdrawalCursorReader::from_slice(slice).map(|reader| reader.to_entity())
     }
     fn from_compatible_slice(slice: &[u8]) -> molecule::error::VerificationResult<Self> {
-        LastFinalizedWithdrawalReader::from_compatible_slice(slice).map(|reader| reader.to_entity())
+        WithdrawalCursorReader::from_compatible_slice(slice).map(|reader| reader.to_entity())
     }
     fn new_builder() -> Self::Builder {
         ::core::default::Default::default()
@@ -668,12 +668,12 @@ impl molecule::prelude::Entity for LastFinalizedWithdrawal {
     fn as_builder(self) -> Self::Builder {
         Self::new_builder()
             .block_number(self.block_number())
-            .withdrawal_index(self.withdrawal_index())
+            .index(self.index())
     }
 }
 #[derive(Clone, Copy)]
-pub struct LastFinalizedWithdrawalReader<'r>(&'r [u8]);
-impl<'r> ::core::fmt::LowerHex for LastFinalizedWithdrawalReader<'r> {
+pub struct WithdrawalCursorReader<'r>(&'r [u8]);
+impl<'r> ::core::fmt::LowerHex for WithdrawalCursorReader<'r> {
     fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
         use molecule::hex_string;
         if f.alternate() {
@@ -682,38 +682,38 @@ impl<'r> ::core::fmt::LowerHex for LastFinalizedWithdrawalReader<'r> {
         write!(f, "{}", hex_string(self.as_slice()))
     }
 }
-impl<'r> ::core::fmt::Debug for LastFinalizedWithdrawalReader<'r> {
+impl<'r> ::core::fmt::Debug for WithdrawalCursorReader<'r> {
     fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
         write!(f, "{}({:#x})", Self::NAME, self)
     }
 }
-impl<'r> ::core::fmt::Display for LastFinalizedWithdrawalReader<'r> {
+impl<'r> ::core::fmt::Display for WithdrawalCursorReader<'r> {
     fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
         write!(f, "{} {{ ", Self::NAME)?;
         write!(f, "{}: {}", "block_number", self.block_number())?;
-        write!(f, ", {}: {}", "withdrawal_index", self.withdrawal_index())?;
+        write!(f, ", {}: {}", "index", self.index())?;
         write!(f, " }}")
     }
 }
-impl<'r> LastFinalizedWithdrawalReader<'r> {
+impl<'r> WithdrawalCursorReader<'r> {
     pub const TOTAL_SIZE: usize = 12;
     pub const FIELD_SIZES: [usize; 2] = [8, 4];
     pub const FIELD_COUNT: usize = 2;
     pub fn block_number(&self) -> Uint64Reader<'r> {
         Uint64Reader::new_unchecked(&self.as_slice()[0..8])
     }
-    pub fn withdrawal_index(&self) -> Uint32Reader<'r> {
+    pub fn index(&self) -> Uint32Reader<'r> {
         Uint32Reader::new_unchecked(&self.as_slice()[8..12])
     }
 }
-impl<'r> molecule::prelude::Reader<'r> for LastFinalizedWithdrawalReader<'r> {
-    type Entity = LastFinalizedWithdrawal;
-    const NAME: &'static str = "LastFinalizedWithdrawalReader";
+impl<'r> molecule::prelude::Reader<'r> for WithdrawalCursorReader<'r> {
+    type Entity = WithdrawalCursor;
+    const NAME: &'static str = "WithdrawalCursorReader";
     fn to_entity(&self) -> Self::Entity {
         Self::Entity::new_unchecked(self.as_slice().to_owned().into())
     }
     fn new_unchecked(slice: &'r [u8]) -> Self {
-        LastFinalizedWithdrawalReader(slice)
+        WithdrawalCursorReader(slice)
     }
     fn as_slice(&self) -> &'r [u8] {
         self.0
@@ -728,11 +728,11 @@ impl<'r> molecule::prelude::Reader<'r> for LastFinalizedWithdrawalReader<'r> {
     }
 }
 #[derive(Debug, Default)]
-pub struct LastFinalizedWithdrawalBuilder {
+pub struct WithdrawalCursorBuilder {
     pub(crate) block_number: Uint64,
-    pub(crate) withdrawal_index: Uint32,
+    pub(crate) index: Uint32,
 }
-impl LastFinalizedWithdrawalBuilder {
+impl WithdrawalCursorBuilder {
     pub const TOTAL_SIZE: usize = 12;
     pub const FIELD_SIZES: [usize; 2] = [8, 4];
     pub const FIELD_COUNT: usize = 2;
@@ -740,27 +740,27 @@ impl LastFinalizedWithdrawalBuilder {
         self.block_number = v;
         self
     }
-    pub fn withdrawal_index(mut self, v: Uint32) -> Self {
-        self.withdrawal_index = v;
+    pub fn index(mut self, v: Uint32) -> Self {
+        self.index = v;
         self
     }
 }
-impl molecule::prelude::Builder for LastFinalizedWithdrawalBuilder {
-    type Entity = LastFinalizedWithdrawal;
-    const NAME: &'static str = "LastFinalizedWithdrawalBuilder";
+impl molecule::prelude::Builder for WithdrawalCursorBuilder {
+    type Entity = WithdrawalCursor;
+    const NAME: &'static str = "WithdrawalCursorBuilder";
     fn expected_length(&self) -> usize {
         Self::TOTAL_SIZE
     }
     fn write<W: molecule::io::Write>(&self, writer: &mut W) -> molecule::io::Result<()> {
         writer.write_all(self.block_number.as_slice())?;
-        writer.write_all(self.withdrawal_index.as_slice())?;
+        writer.write_all(self.index.as_slice())?;
         Ok(())
     }
     fn build(&self) -> Self::Entity {
         let mut inner = Vec::with_capacity(self.expected_length());
         self.write(&mut inner)
             .unwrap_or_else(|_| panic!("{} build should be ok", Self::NAME));
-        LastFinalizedWithdrawal::new_unchecked(inner.into())
+        WithdrawalCursor::new_unchecked(inner.into())
     }
 }
 #[derive(Clone)]
@@ -1113,8 +1113,8 @@ impl ::core::fmt::Display for GlobalState {
         write!(
             f,
             ", {}: {}",
-            "last_finalized_withdrawal",
-            self.last_finalized_withdrawal()
+            "finalized_withdrawal_cursor",
+            self.finalized_withdrawal_cursor()
         )?;
         write!(f, ", {}: {}", "status", self.status())?;
         write!(f, ", {}: {}", "version", self.version())?;
@@ -1160,8 +1160,8 @@ impl GlobalState {
     pub fn last_finalized_block_number(&self) -> Uint64 {
         Uint64::new_unchecked(self.0.slice(180..188))
     }
-    pub fn last_finalized_withdrawal(&self) -> LastFinalizedWithdrawal {
-        LastFinalizedWithdrawal::new_unchecked(self.0.slice(188..200))
+    pub fn finalized_withdrawal_cursor(&self) -> WithdrawalCursor {
+        WithdrawalCursor::new_unchecked(self.0.slice(188..200))
     }
     pub fn status(&self) -> Byte {
         Byte::new_unchecked(self.0.slice(200..201))
@@ -1203,7 +1203,7 @@ impl molecule::prelude::Entity for GlobalState {
             .tip_block_hash(self.tip_block_hash())
             .tip_block_timestamp(self.tip_block_timestamp())
             .last_finalized_block_number(self.last_finalized_block_number())
-            .last_finalized_withdrawal(self.last_finalized_withdrawal())
+            .finalized_withdrawal_cursor(self.finalized_withdrawal_cursor())
             .status(self.status())
             .version(self.version())
     }
@@ -1252,8 +1252,8 @@ impl<'r> ::core::fmt::Display for GlobalStateReader<'r> {
         write!(
             f,
             ", {}: {}",
-            "last_finalized_withdrawal",
-            self.last_finalized_withdrawal()
+            "finalized_withdrawal_cursor",
+            self.finalized_withdrawal_cursor()
         )?;
         write!(f, ", {}: {}", "status", self.status())?;
         write!(f, ", {}: {}", "version", self.version())?;
@@ -1285,8 +1285,8 @@ impl<'r> GlobalStateReader<'r> {
     pub fn last_finalized_block_number(&self) -> Uint64Reader<'r> {
         Uint64Reader::new_unchecked(&self.as_slice()[180..188])
     }
-    pub fn last_finalized_withdrawal(&self) -> LastFinalizedWithdrawalReader<'r> {
-        LastFinalizedWithdrawalReader::new_unchecked(&self.as_slice()[188..200])
+    pub fn finalized_withdrawal_cursor(&self) -> WithdrawalCursorReader<'r> {
+        WithdrawalCursorReader::new_unchecked(&self.as_slice()[188..200])
     }
     pub fn status(&self) -> ByteReader<'r> {
         ByteReader::new_unchecked(&self.as_slice()[200..201])
@@ -1325,7 +1325,7 @@ pub struct GlobalStateBuilder {
     pub(crate) tip_block_hash: Byte32,
     pub(crate) tip_block_timestamp: Uint64,
     pub(crate) last_finalized_block_number: Uint64,
-    pub(crate) last_finalized_withdrawal: LastFinalizedWithdrawal,
+    pub(crate) finalized_withdrawal_cursor: WithdrawalCursor,
     pub(crate) status: Byte,
     pub(crate) version: Byte,
 }
@@ -1361,8 +1361,8 @@ impl GlobalStateBuilder {
         self.last_finalized_block_number = v;
         self
     }
-    pub fn last_finalized_withdrawal(mut self, v: LastFinalizedWithdrawal) -> Self {
-        self.last_finalized_withdrawal = v;
+    pub fn finalized_withdrawal_cursor(mut self, v: WithdrawalCursor) -> Self {
+        self.finalized_withdrawal_cursor = v;
         self
     }
     pub fn status(mut self, v: Byte) -> Self {
@@ -1388,7 +1388,7 @@ impl molecule::prelude::Builder for GlobalStateBuilder {
         writer.write_all(self.tip_block_hash.as_slice())?;
         writer.write_all(self.tip_block_timestamp.as_slice())?;
         writer.write_all(self.last_finalized_block_number.as_slice())?;
-        writer.write_all(self.last_finalized_withdrawal.as_slice())?;
+        writer.write_all(self.finalized_withdrawal_cursor.as_slice())?;
         writer.write_all(self.status.as_slice())?;
         writer.write_all(self.version.as_slice())?;
         Ok(())

--- a/crates/types/src/offchain/pool.rs
+++ b/crates/types/src/offchain/pool.rs
@@ -2,7 +2,7 @@ use ckb_types::bytes::Bytes;
 use sparse_merkle_tree::H256;
 
 use crate::packed::{
-    AccountMerkleState, L2Block, L2Transaction, LastFinalizedWithdrawal, WithdrawalRequestExtra,
+    AccountMerkleState, L2Block, L2Transaction, WithdrawalCursor, WithdrawalRequestExtra,
 };
 
 use super::DepositInfo;
@@ -21,5 +21,5 @@ pub struct BlockParam {
     pub post_merkle_state: AccountMerkleState,
     pub kv_state: Vec<(H256, H256)>,
     pub kv_state_proof: Vec<u8>,
-    pub last_finalized_withdrawal: LastFinalizedWithdrawal,
+    pub last_finalized_withdrawal: WithdrawalCursor,
 }


### PR DESCRIPTION
1. Refactor `WithdrawalCursor` structure.
2. We will use `WithdrawalCursor` in the godwoken-scripts, to reduce duplicated code.
3. Rename some field & functions with more reasonable name.